### PR TITLE
fix: drop event if beforeSend returns null

### DIFF
--- a/libs/core/src/lib/service/micro-sentry-client.ts
+++ b/libs/core/src/lib/service/micro-sentry-client.ts
@@ -64,7 +64,7 @@ export class MicroSentryClient {
   }
 
   protected send(request: SentryRequest) {
-    if (!this.apiUrl) {
+    if (!this.apiUrl || !request) {
       return;
     }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?

## What is the new behavior?

The sentry javascript SDK allows event filtering by returning `null` from the `beforeSend` callback.
See https://docs.sentry.io/platforms/javascript/configuration/filtering/

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
